### PR TITLE
Convert Date of birth to Prisma/GQL format date

### DIFF
--- a/src/components/users/Profile.js
+++ b/src/components/users/Profile.js
@@ -89,13 +89,8 @@ const Profile = (props) => {
 		e.preventDefault()
 		if (user.dob) {
 			const dob = user.dob.split('/')
-			const mom = moment()
-			await mom.set({
-				year: dob[0],
-				month: dob[1],
-				date: dob[2],
-			})
-			await setUser({ ...user, dob: mom.unix() })
+			const prismaString = dob[0] + dob[1] + dob[2] + "T00:00:00Z";
+			await setUser({ ...user, dob: prismaString })
 		}
 		const payload = {
 			query: `mutation{


### PR DESCRIPTION
Prisma/GQL only allow dates to be stored in YYYY-MM-DDTHH:MM:SSZ but returns them in unix timestamps (don't ask me why)
This just converts from YYYY/MM/DD to the above format. _**This hasnt been correctly tested yet**_